### PR TITLE
Allow to override base image in our docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG BASE_IMAGE=registry.opensuse.org/cloud/platform/quarks/sle_15_sp1/quarks-operator-base:latest
+
 FROM golang:1.13.4 AS build
 ARG GOPROXY
 ENV GOPROXY $GOPROXY
@@ -16,7 +18,7 @@ COPY . .
 RUN bin/build && \
     cp -p binaries/quarks-secret /usr/local/bin/quarks-secret
 
-FROM registry.opensuse.org/cloud/platform/quarks/sle_15_sp1/quarks-operator-base:latest
+FROM $BASE_IMAGE
 RUN groupadd -g 1000 quarks && \
     useradd -r -u 1000 -g quarks quarks
 USER quarks


### PR DESCRIPTION
Allow to swap base image. The base image needs to ship the required dependencies (e.g. dumb-init)

## Motivation and Context

[#173530438](https://www.pivotaltracker.com/story/show/173530438)

## Checklist:

Check item if necessary.

- [ ] Review PRs of changed Quarks dependencies
- [ ] Update this PR after the release of Quarks dependencies
