### PR TITLE
Address gosec G601, ineffassign

### DIFF
--- a/pkg/kube/controllers/quarkssecret/quarkssecret_controller.go
+++ b/pkg/kube/controllers/quarkssecret/quarkssecret_controller.go
@@ -110,7 +110,8 @@ func listSecrets(ctx context.Context, client crc.Client, qsec *qsv1a1.QuarksSecr
 		return nil, err
 	}
 
-	for _, secret := range allSecrets.Items {
+	for _, s := range allSecrets.Items {
+		secret := s
 		if metav1.IsControlledBy(&secret, qsec) {
 			result = append(result, secret)
 			ctxlog.Debug(ctx, "Found Secret '", secret.Name, "' owned by QuarksSecret '", qsec.GetNamespacedName(), "'")

--- a/pkg/kube/util/mutate/mutate_test.go
+++ b/pkg/kube/util/mutate/mutate_test.go
@@ -88,9 +88,9 @@ var _ = Describe("Mutate", func() {
 
 			It("does not update the quarksSecret when nothing is changed", func() {
 				client.GetCalls(func(context context.Context, nn types.NamespacedName, object runtime.Object) error {
-					switch object.(type) {
+					switch object := object.(type) {
 					case *qsv1a1.QuarksSecret:
-						object = qSec.DeepCopy()
+						qSec.DeepCopyInto(object)
 
 						return nil
 					}


### PR DESCRIPTION
Fixed below golang-lint issues:
```
pkg/kube/controllers/quarkssecret/quarkssecret_controller.go:114:28: G601: Implicit memory aliasing in for loop. (gosec)
		if metav1.IsControlledBy(&secret, qsec) {
		                         ^
pkg/kube/util/mutate/mutate_test.go:93:7: ineffectual assignment to `object` (ineffassign)
						object = qSec.DeepCopy()
						^
INFO File cache stats: 4 entries of total size 15.5KiB
INFO Memory: 20 samples, avg is 118.4MB, max is 271.6MB
INFO Execution took 1.868174288s
```

After that,

```
 $ golangci-lint run -v --modules-download-mode=readonly
INFO [config_reader] Config search paths: [./ /Users/zidashaw/space/golang/workspace/src/code.cloudfoundry.org/quarks-secret /Users/zidashaw/space/golang/workspace/src/code.cloudfoundry.org /Users/zidashaw/space/golang/workspace/src /Users/zidashaw/space/golang/workspace /Users/zidashaw/space/golang /Users/zidashaw/space /Users/zidashaw /Users /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 13 linters: [deadcode gocyclo gofmt golint gosec gosimple govet ineffassign misspell staticcheck structcheck unused varcheck]
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|exports_file|files|imports|name|types_sizes) took 1.216248296s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 7.678856ms
INFO [linters context/goanalysis] analyzers took 0s with no stages
INFO [linters context/goanalysis] analyzers took 0s with no stages
INFO [runner/skip dirs] Skipped 4 issues from dir pkg/kube/client/clientset/versioned/scheme by pattern pkg/kube/client
INFO [runner/skip dirs] Skipped 4 issues from dir pkg/kube/client/clientset/versioned/typed/quarkssecret/v1alpha1/fake by pattern pkg/kube/client
INFO [runner/skip dirs] Skipped 4 issues from dir pkg/kube/client/clientset/versioned/typed/quarkssecret/v1alpha1 by pattern pkg/kube/client
INFO [runner/skip dirs] Skipped 6 issues from dir pkg/kube/client/clientset/versioned/fake by pattern pkg/kube/client
INFO [runner/skip dirs] Skipped 2 issues from dir pkg/kube/client/clientset/versioned by pattern pkg/kube/client
INFO [runner] Issues before processing: 220, after processing: 0
INFO [runner] Processors filtering stat (out/in): cgo: 220/220, filename_unadjuster: 220/220, autogenerated_exclude: 12/200, skip_files: 220/220, identifier_marker: 12/12, exclude: 0/12, path_prettifier: 220/220, skip_dirs: 200/220
INFO [runner] processing took 2.267616ms with stages: path_prettifier: 1.626014ms, autogenerated_exclude: 227.247µs, skip_dirs: 182.666µs, identifier_marker: 106.808µs, exclude: 93.896µs, cgo: 15.687µs, filename_unadjuster: 12.059µs, nolint: 1.023µs, max_same_issues: 568ns, diff: 263ns, uniq_by_line: 260ns, max_from_linter: 221ns, source_code: 205ns, skip_files: 201ns, exclude-rules: 198ns, max_per_file_from_linter: 151ns, path_shortener: 149ns
INFO [runner] linters took 314.897958ms with stages: goanalysis_metalinter: 310.831559ms, unused: 1.747899ms
INFO File cache stats: 0 entries of total size 0B
INFO Memory: 18 samples, avg is 87.1MB, max is 139.4MB
INFO Execution took 1.601252655s
```