### PR TITLE
fix Dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /go/src/code.cloudfoundry.org/quarks-secret
 
 # Copy the rest of the source code and build
 COPY . .
+RUN make tools
 RUN bin/build && \
     cp -p binaries/quarks-secret /usr/local/bin/quarks-secret
 


### PR DESCRIPTION
The build of this Dockerfile started failing a little while ago.

This commit makes sure that the required tools are present before running
`bin/build`

We chatted with some of you on [Slack](https://cloudfoundry.slack.com/archives/C1BQKKNP4/p1597944877012100) last week about it. 
We weren't sure if we communicated properly the change we were thinking of making, so we just made the PR so you know exactly what we meant. Please let us know if you think that's not an acceptable change.

I think that it also makes sense to add the `make tools` to the `bin/build` script itself, since you probably can't run `bin/build` without having run `make tools`, even outside of the container.

@peterhaochen47 and I
