### PR TITLE
Add support for generating TLS type

### DIFF
--- a/docs/crds/quarks_v1alpha1_quarkssecret_crd.yaml
+++ b/docs/crds/quarks_v1alpha1_quarkssecret_crd.yaml
@@ -43,7 +43,7 @@ spec:
               type: string
             type:
               description: 'What kind of secret to generate: password, certificate,
-                ssh, rsa, basic-auth'
+                ssh, rsa, basic-auth, tls'
               minLength: 1
               type: string
           required:

--- a/docs/examples/ca.yaml
+++ b/docs/examples/ca.yaml
@@ -1,0 +1,13 @@
+apiVersion: quarks.cloudfoundry.org/v1alpha1
+kind: QuarksSecret
+metadata:
+  name: example.quarks.ca
+spec:
+  request:
+    certificate:
+      alternativeNames: null
+      commonName: someExampleCA
+      isCA: true
+      signerType: local
+  secretName: example.secret.ca
+  type: certificate

--- a/docs/examples/tls.yaml
+++ b/docs/examples/tls.yaml
@@ -1,0 +1,35 @@
+apiVersion: quarks.cloudfoundry.org/v1alpha1
+kind: QuarksSecret
+metadata:
+  name: example.quarks.tls
+spec:
+  request:
+    certificate:
+      CAKeyRef:
+        key: private_key
+        name: example.secret.ca
+      CARef:
+        key: certificate
+        name: example.secret.ca
+      alternativeNames: null
+      commonName: kubeTlsTypeCert
+      isCA: false
+      signerType: local
+  secretName: example.secret.tls
+  type: tls
+
+---
+
+apiVersion: quarks.cloudfoundry.org/v1alpha1
+kind: QuarksSecret
+metadata:
+  name: example.quarks.tls
+spec:
+  request:
+    certificate:
+      alternativeNames: null
+      commonName: kubeTlsTypeCert
+      isCA: false
+      signerType: cluster
+  secretName: example.secret.tls
+  type: tls

--- a/e2e/kube/examples_count_test.go
+++ b/e2e/kube/examples_count_test.go
@@ -19,6 +19,6 @@ var _ = Describe("Examples Directory Files", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		// If this testcase fails that means a test case is missing for an example in the docs folder
-		Expect(countFile).To(Equal(13))
+		Expect(countFile).To(Equal(15))
 	})
 })

--- a/pkg/kube/apis/quarkssecret/v1alpha1/types.go
+++ b/pkg/kube/apis/quarkssecret/v1alpha1/types.go
@@ -21,6 +21,7 @@ type SecretType = string
 const (
 	Password         SecretType = "password"
 	Certificate      SecretType = "certificate"
+	TLS              SecretType = "tls"
 	SSHKey           SecretType = "ssh"
 	RSAKey           SecretType = "rsa"
 	BasicAuth        SecretType = "basic-auth"

--- a/testing/catalog.go
+++ b/testing/catalog.go
@@ -68,6 +68,27 @@ func (c *Catalog) CertificateQuarksSecret(name string, secretref string, cacertr
 	}
 }
 
+// TLSQuarksSecret for use in tests, creates a tls type secret
+func (c *Catalog) TLSQuarksSecret(name string, secretref string, cacertref string, keyref string) qsv1a1.QuarksSecret {
+	return qsv1a1.QuarksSecret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: qsv1a1.QuarksSecretSpec{
+			SecretName: "generated-cert-secret",
+			Type:       "tls",
+			Request: qsv1a1.Request{
+				CertificateRequest: qsv1a1.CertificateRequest{
+					CommonName:       "example.com",
+					CARef:            qsv1a1.SecretReference{Name: secretref, Key: cacertref},
+					CAKeyRef:         qsv1a1.SecretReference{Name: secretref, Key: keyref},
+					AlternativeNames: []string{"qux.com"},
+				},
+			},
+		},
+	}
+}
+
 // SSHQuarksSecret returns a 'ssh' type quarks secret for testing
 func (c *Catalog) SSHQuarksSecret(name string) qsv1a1.QuarksSecret {
 	return qsv1a1.QuarksSecret{


### PR DESCRIPTION
- The TLS type is a k8s standard Secret type
(see [k8s docs](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls))
- More context on [slack](https://cloudfoundry.slack.com/archives/C1BQKKNP4/p1597786459008200)