### PR TITLE
Use namespace to generate Release.fullname

### DIFF
--- a/deploy/helm/quarks-secret/templates/_helpers.tpl
+++ b/deploy/helm/quarks-secret/templates/_helpers.tpl
@@ -16,8 +16,8 @@ If release name contains chart name it will be used as a full name.
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- if contains $name .Release.Namespace -}}
+{{- .Release.Namespace | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -36,7 +36,7 @@ Create the name of the quarks-secret service account to use
 */}}
 {{- define "quarks-secret.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
-    {{ default (include "quarks-secret.fullname" .) .Values.serviceAccount.name }}
+    {{ default (include "quarks-secret.name" .) .Values.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}

--- a/deploy/helm/quarks-secret/templates/operator.yaml
+++ b/deploy/helm/quarks-secret/templates/operator.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "quarks-secret.fullname" . }}
+  name: {{ template "quarks-secret.name" . }}
   namespace: "{{ .Release.Namespace }}"
 spec:
   replicas: 1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module code.cloudfoundry.org/quarks-secret
 go 1.15
 
 require (
-	code.cloudfoundry.org/quarks-utils v0.0.2-0.20210225151037-f17676b0c328
+	code.cloudfoundry.org/quarks-utils v0.0.2
 	github.com/cloudflare/cfssl v1.4.1
 	github.com/dchest/uniuri v0.0.0-20200228104902-7aecb25e1fe5
 	github.com/go-logr/logr v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIA
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0ZeosJ0Rtdos=
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
-code.cloudfoundry.org/quarks-utils v0.0.2-0.20210225151037-f17676b0c328 h1:5L5GGgWdsC6hNJQ4JF4LUMTFn5fnYa82Q+WerPlAY5Q=
-code.cloudfoundry.org/quarks-utils v0.0.2-0.20210225151037-f17676b0c328/go.mod h1:chUN4PKXqnLDSe6zkUvmR5RnjysI87arFtDME1xHP/k=
+code.cloudfoundry.org/quarks-utils v0.0.2 h1:ONFYFBKo4saNKdTo8StcYo/71+3skCoj0fIakInHnbY=
+code.cloudfoundry.org/quarks-utils v0.0.2/go.mod h1:chUN4PKXqnLDSe6zkUvmR5RnjysI87arFtDME1xHP/k=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=


### PR DESCRIPTION
Also reduce the other names, only prefix cluster-wide resources with
fullname.

[#175984792](https://www.pivotaltracker.com/story/show/175984792)