### PR TITLE
Generate lite image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ jobs:
         registry: "${{ env.DOCKER_IMAGE_ORG }}"
         image_name: "${{ env.DOCKER_IMAGE_REPOSITORY }}"
         image_tag: "${{ steps.prepare_version_env.outputs.version }}-lite"
-        build_extra_args: '{"--build-arg": "BASE_IMAGE=scratch"}'
+        dockerfile: Dockerfile-lite
 
     - name: Build Helm Chart
       run: |

--- a/Dockerfile-lite
+++ b/Dockerfile-lite
@@ -1,0 +1,19 @@
+ARG BASE_IMAGE=scratch
+
+FROM golang:1.15.8 AS build
+ARG GOPROXY
+ENV GOPROXY $GOPROXY
+
+WORKDIR /go/src/code.cloudfoundry.org/quarks-secret
+
+# Copy the rest of the source code and build
+COPY . .
+RUN [ -f tools/quarks-utils/bin/include/versioning ] || \
+    bin/tools
+RUN bin/build && \
+    cp -p binaries/quarks-secret /usr/local/bin/quarks-secret
+
+FROM $BASE_IMAGE
+LABEL org.opencontainers.image.source https://github.com/cloudfoundry-incubator/quarks-secret
+COPY --from=build /usr/local/bin/quarks-secret /usr/local/bin/quarks-secret
+ENTRYPOINT ["/usr/local/bin/quarks-secret"]


### PR DESCRIPTION
Fix the publish pipeline (broke with this: https://github.com/cloudfoundry-incubator/quarks-secret/pull/122) by providing a different (and working) Dockerfile for the lite image.